### PR TITLE
Add GitHub Action for automated release to PyPI

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Get diff for pyproject.toml
       id: diff
       run: |
-        git diff origin/master -- pyproject.toml > version.diff
+        git diff origin/main -- pyproject.toml > version.diff
         if grep -q '^+version *= *' version.diff; then
           echo "Version bump detected ✅"
         else

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -3,7 +3,7 @@ name: Check Version Bump
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   ensure-version-bump:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release to PyPI
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    name: Build & Publish to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install build dependencies
+      run: pip install build twine
+
+    - name: Build the package
+      run: python -m build
+
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: twine upload dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "egyptian-id-validator"
-version = "0.2.0"
+version = "0.3.0"
 description = "A Python package for validating Egyptian National IDs."
 authors = [
     { name = "Mohamed A. Abdallah", email = "eng.mohamed.a.abdallah@gmail.com" }


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow that automates the process of building and publishing the package to PyPI upon each push to the master branch.

- Sets up a release.yml workflow using twine and build.
- Publishes the distribution to PyPI using a secure API token stored in PYPI_API_TOKEN.
- Triggered only when changes are pushed to master.

> Note:
> This PR is intentionally submitted without a version bump in pyproject.toml.
> It is expected to fail the version bump check, as a test to confirm that the previously implemented version enforcement workflow functions correctly.